### PR TITLE
Add server capabilities to client cert

### DIFF
--- a/configs/openssl-client.cnf
+++ b/configs/openssl-client.cnf
@@ -38,8 +38,8 @@ emailAddress_default        = test@example.com
 subjectKeyIdentifier    = hash
 #authorityKeyIdentifier = keyid:always, issuer:always
 basicConstraints        = critical, CA:FALSE
-keyUsage                = critical, digitalSignature, keyEncipherment
-extendedKeyUsage        = critical, clientAuth
+keyUsage                = critical, digitalSignature, keyEncipherment, keyAgreement
+extendedKeyUsage        = critical, serverAuth, clientAuth
 nsComment               = "OpenSSL Generated Client Certificate"
 
 ####################################################################


### PR DESCRIPTION
This is needed so that the client certificate can be used in 802.1x
onboarding to authenticate other nodes.